### PR TITLE
[BUG] Helm dependency update before package

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -6,7 +6,8 @@ temp_dir=onefootball-charts
 mkdir ${temp_dir}
 git archive gh-pages | tar -xv -C ${temp_dir}
 for app in ${apps}; do
-	helm package ${app}/
+    helm dependency update ${app}/
+    helm package ${app}/
 done
 
 cp *.tgz ${temp_dir}/


### PR DESCRIPTION
Sentry is our first package with dependencies and it depends on a `helm dependency update` to be packaged